### PR TITLE
add new configs/secrets directories

### DIFF
--- a/core/src/org/purefn/kurosawa/k8s.clj
+++ b/core/src/org/purefn/kurosawa/k8s.clj
@@ -1,8 +1,9 @@
 (ns org.purefn.kurosawa.k8s
   "Kubernetes configuration and deployment helpers."
-  (:require [clojure.spec.alpha :as s]
+  (:require [clojure.java.io :as io]
+            [clojure.java.shell :as shell]
+            [clojure.spec.alpha :as s]
             [clojure.spec.gen.alpha :as gen]
-            [clojure.java.io :as io]
             [clojure.string :as str]
             [org.purefn.kurosawa.result :refer :all])
   (:import [java.io File]))
@@ -21,7 +22,7 @@
 (defn- read-configs
   [dir]
   (let [n (-> (str/split dir #"/")
-              (count))                 
+              (count))
         ^File root (io/file dir)
         dir? (fn [^File fd] (.isDirectory fd))
         files (fn [^File d]
@@ -43,16 +44,34 @@
          (filter (comp not dir?))
          (map pairs)
          (reduce (fn [m [p v]] (assoc-in m p v)) {}))))
-         
+
+(defn mount-directory
+  "Provides mount directory for configs/secrets
+
+   Configs were originally in /etc/configs, but for flexibility
+   we moved configs to the project parent level, e.g. for service
+   `get-shorty`, this would be /opt/configs, since /opt/get-shorty
+   would be our project directory.
+
+   By supporting both setups, we avoid needing to updated all deploy
+   projects at the same time. Function name could seem odd, but its
+   relates to how kubernetes required volume mounts."
+  [type]
+  (let [parent-path  (.getParent (io/file (str/trim (:out (shell/sh "pwd")))))
+        desired-dir  (str parent-path "/" type "/")
+        fallback-dir (str "/etc/" type "/")]
+  (if (.isDirectory (io/file desired-dir))
+    desired-dir
+    fallback-dir)))
 
 (defn config-map
   "Read the Kubernetes ConfigMap from container local disk.
 
    - `name` The base name of the configuration (if any).
-   
+
    Returns a nested map of configuration parameters."
   ([name]
-   (read-configs (str "/etc/configs/" name)))
+   (read-configs (str (mount-directory "configs") name)))
   ([]
    (config-map "")))
 
@@ -60,14 +79,14 @@
   "Read the Kubernetes Secrets from container local disk.
 
    - `name` The base name of the secrets (if any).
-   
+
    Returns a nested map of plain text secrets."
   ([name]
-   (read-configs (str "/etc/secrets/" name)))
+   (read-configs (str (mount-directory "secrets") name)))
   ([]
    (secrets "")))
 
 
 ;;------------------------------------------------------------------------------
-;; Specs. 
+;; Specs.
 ;;------------------------------------------------------------------------------


### PR DESCRIPTION
Allow configs to be mounted at `/path-to-project-parent/configs/` vs `/etc/configs/`.