### PR TITLE
Nrepl bind

### DIFF
--- a/nrepl/src/org/purefn/kurosawa/nrepl.clj
+++ b/nrepl/src/org/purefn/kurosawa/nrepl.clj
@@ -26,8 +26,9 @@
         (log/info "CiderReplServer already started on port" (::port config))
         this)
       (let [port (::port config)
-            _ (log/info "Starting CiderReplServer on port" port)
+            _ (log/info "Starting CiderReplServer on port" port "and bind to localhost")
             srv (repl/start-server :port port
+                                   :bind "localhost"
                                    :handler (nrepl-handler))]
         (assoc this :server srv))))
   (stop [this]

--- a/nrepl/src/org/purefn/kurosawa/nrepl.clj
+++ b/nrepl/src/org/purefn/kurosawa/nrepl.clj
@@ -26,7 +26,7 @@
         (log/info "CiderReplServer already started on port" (::port config))
         this)
       (let [port (::port config)
-            _ (log/info "Starting CiderReplServer on port" port "and bind to localhost")
+            _ (log/info "Starting CiderReplServer on port" port)
             srv (repl/start-server :port port
                                    :bind "localhost"
                                    :handler (nrepl-handler))]


### PR DESCRIPTION
The default value for `:bind`, "::", will fail in some Docker networking environments.  `localhost` is probably where we want to bind the nrepl server to, by default.