### PR TITLE
A generic route not found handler.

### DIFF
--- a/web/src/org/purefn/kurosawa/web/handler.clj
+++ b/web/src/org/purefn/kurosawa/web/handler.clj
@@ -1,0 +1,9 @@
+(ns org.purefn.kurosawa.web.handler
+  (:require [taoensso.timbre :as log]))
+
+(defn not-found
+  [{:keys [request-method uri]}]
+  (let [msg (format "%s %s not found" request-method uri)]
+    (log/warn msg)
+    {:status 404
+     :body msg}))

--- a/web/src/org/purefn/kurosawa/web/prometheus.clj
+++ b/web/src/org/purefn/kurosawa/web/prometheus.clj
@@ -17,7 +17,7 @@
            (remove (comp (set ignore-keys)
                          first))
            (reduce (fn [path [p v]]
-                     (str/replace path (re-pattern v) (str p)))
+                     (str/replace path v (str p)))
                    uri))
       uri))
 


### PR DESCRIPTION
The Prometheus middleware wasn't properly replacing route parameters when they contained characters which have special meaning in regular expressions, e.g. `/` in
```
user/1234 -> user/:user-id
key/2019/11/02/some_file.pdf -> key/:key
```
This patch fixes the second case, which wasn't working, and therefore producing a high cardinality label (path) for HTTP metrics time series.

Also included is a generic "not found" route handler.