### PR TITLE
Fix s3 parsing bug

### DIFF
--- a/aws/src/org/purefn/kurosawa/aws/s3.clj
+++ b/aws/src/org/purefn/kurosawa/aws/s3.clj
@@ -46,14 +46,19 @@
 
 ;; temporarily needed while moving from k8s configs where all things are stringly
 ;; typed.
-(def ^:private parse
-  (some-fn #(try (Integer. %)
-                 (catch Exception ex))
-           #(try (Long. %)
-                 (catch Exception ex))
-           #(try (Double. %)
-                 (catch Exception ex))
-           identity))
+(def parse
+  (comp 
+   (some-fn #(try (Integer. %)
+                  (catch Exception ex))
+            #(try (Long. %)
+                  (catch Exception ex))
+            #(try (Double. %)
+                  (catch Exception ex))
+            identity)
+   (fn [s]
+     (if (string? s)
+       (str/trim s)
+       s))))
 
 (def ^:private basename
   (comp
@@ -117,7 +122,7 @@
        (map (fn [[n kvs]]
               [n
                (map (juxt (comp identity key)
-                          (comp parse str/trim val))
+                          (comp parse val))
                     kvs)]))
        (reduce (fn [conf [k vs]]
                  (merge-with merge conf {k (into {} vs)}))

--- a/aws/test/org/purefn/kurosawa/aws/s3_test.clj
+++ b/aws/test/org/purefn/kurosawa/aws/s3_test.clj
@@ -1,0 +1,18 @@
+(ns org.purefn.kurosawa.aws.s3-test
+  (:require [clojure.test :refer :all]
+            [org.purefn.kurosawa.aws.s3 :as s3]))
+
+;; These tests show the config parsing contract.  The config source
+;; originally started as files on disk, then k8s secrets, and is
+;; finally now json in s3 and environment vars.
+(deftest parsing
+  (testing "Integer parsing"
+    (is (= 10000 (s3/parse "10000")))
+    (is (= 10000 (s3/parse "10000 ")))
+    (is (= 10000 (s3/parse 10000))))
+  (testing "Double parsing"
+    (is (= 10000.0 (s3/parse "10000.0")))
+    (is (= 10000.0 (s3/parse 10000.0))))
+  (testing "String parsing"
+    (is (= "anything else" (s3/parse "anything else")))))
+


### PR DESCRIPTION
- Fixes a bug where non-string values (only supported in the s3
  storage backend) would throw during load on s3/trim
- Add tests showing/asserting s3 parse contract