### PR TITLE
Adding middleware protocol to web app namespace

### DIFF
--- a/web/src/org/purefn/kurosawa/web/app.clj
+++ b/web/src/org/purefn/kurosawa/web/app.clj
@@ -25,6 +25,18 @@
 (defrecord App
     [config handler])
 
+;;------------------------------------------------------------------------------
+;; Middleware
+;;
+;; This protocol can be implemented and used to apply middleware to the handler
+;; function provided to the `App`. The component would then need to be part of
+;; the `SystemMap` under the key :middleware.
+;;
+;; The use case for this type of middleware would be that which is dependent on
+;; a stateful component that needs to be used by other components within the
+;; `SystemMap`.
+;;------------------------------------------------------------------------------
+
 (defprotocol Middleware
   (apply-middleware [this handler]))
 

--- a/web/src/org/purefn/kurosawa/web/app.clj
+++ b/web/src/org/purefn/kurosawa/web/app.clj
@@ -27,18 +27,17 @@
 
 ;;------------------------------------------------------------------------------
 ;; Middleware
-;;
-;; This protocol can be implemented and used to apply middleware to the handler
-;; function provided to the `App`. The component would then need to be part of
-;; the `SystemMap` under the key :middleware.
-;;
-;; The use case for this type of middleware would be that which is dependent on
-;; a stateful component that needs to be used by other components within the
-;; `SystemMap`.
 ;;------------------------------------------------------------------------------
 
 (defprotocol Middleware
-  (apply-middleware [this handler]))
+  "This protocol can be implemented and used to apply middleware to the handler
+  function provided to the `App`. The component would then need to be part of
+  the `SystemMap` under the key :middleware.
+
+  The use case for this would be middleware which is dependent on a stateful
+  component that needs to be used by other components within the `SystemMap`"
+  (apply-middleware [this handler]
+   "Returns `handler` with middleware applied"))
 
 (defn wrap-services
   "Middleware that wraps a handler with given services map."


### PR DESCRIPTION
I wrote out the abstract use case, but more specifically we were using the prometheus registry defined [here](https://github.com/PureFnOrg/kurosawa/blob/master/web/src/org/purefn/kurosawa/web/prometheus.clj#L24) and need to add it to the system map in order to register metrics in other components used by the web application. We'd like to eventually deprecate that `defonce` in favor of this pattern.