### PR TITLE
Add thread-pool instrumentation support for web server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+/.clj-kondo
+/.lsp

--- a/web/project.clj
+++ b/web/project.clj
@@ -12,4 +12,5 @@
                  [org.purefn/kurosawa.log _]]
 
   :profiles {:dev {:dependencies [[bidi "2.0.17"]
-                                  [clj-commons/iapetos "0.1.9"]]}})
+                                  [clj-commons/iapetos "0.1.9"]
+                                  [preflex "0.4.0"]]}})

--- a/web/src/org/purefn/kurosawa/web/instrument.clj
+++ b/web/src/org/purefn/kurosawa/web/instrument.clj
@@ -1,0 +1,82 @@
+(ns org.purefn.kurosawa.web.instrument
+  "Thread-pool instrumentation for Ring-compliant web server. In most cases you may want
+   to use only `initialize` and `instrument` and use the output to launch the web server.
+
+   This library does not include prometheus (iapetos and bidi) and preflex as dependencies
+   directly, so requiring this namespace will break unless you've done so yourself."
+  (:require [iapetos.core :as prometheus]
+            [preflex.instrument :as i]
+            [preflex.resilient :as r]
+            [preflex.type :as t])
+  (:import [java.util.concurrent ThreadPoolExecutor]))
+
+;; --- prometheus collectors/registry ---
+
+(def thread-count-collector (prometheus/gauge :http/thread-count
+                                              {:description "active thread count for HTTP requests"
+                                               :labels      []}))
+
+(def waiting-count-collector (prometheus/gauge :http/waiting-count
+                                               {:description "thread-pool queue size for HTTP requests"
+                                                :labels      []}))
+
+(def wait-time-ms-collector (prometheus/gauge :http/wait-time-ms
+                                              {:description "wait-time (millis) for HTTP requests"
+                                               :labels      []}))
+
+(defn initialize
+  "Initialize all collectors for thread-pool instrumentation, including
+   - http_thread_count
+   - http_waiting_count
+   - http_wait_time_ms"
+  [registry]
+  (-> registry
+      (prometheus/register
+       thread-count-collector
+       waiting-count-collector
+       wait-time-ms-collector)))
+
+;; --- thread-pool instrumentation ---
+
+(def ^:dynamic *context* {})
+
+(defn wrap-queue-latency-middleware
+  [f registry bounded-thread-pool]
+  (fn [request]
+    (-> registry
+        (prometheus/set :http/thread-count (.getPoolSize ^ThreadPoolExecutor (t/thread-pool bounded-thread-pool)))
+        (prometheus/set :http/waiting-count (t/queue-size bounded-thread-pool)))
+    (when-some [dqm (:duration-queue-ms *context*)]
+      (prometheus/set registry :http/wait-time-ms dqm))
+    (f request)))
+
+(defn make-server-thread-pool [thread-count queue-size]
+  (let [bounded-pool (r/make-bounded-thread-pool thread-count queue-size)
+        task-invoker (fn [g context] (binding [*context* context]
+                                       (g)))
+        instrumented (i/instrument-thread-pool
+                      bounded-pool
+                      (assoc i/shared-context-thread-pool-task-wrappers-millis
+                             :callable-decorator (i/make-shared-context-callable-decorator task-invoker)
+                             :runnable-decorator (i/make-shared-context-runnable-decorator task-invoker)))]
+    {:bounded-thread-pool      bounded-pool
+     :instrumented-thread-pool instrumented}))
+
+(defn instrument
+  "Given Prometheus registry, Ring handler fn and thread-pool parameters,
+   construct a bounded thread-pool and return a map containing following
+   instrumented objects:
+
+   | Key          | Value description |
+   |--------------|-------------------|
+   | :handler     | Ring handler that log Prometheus metrics for the thread-pool  |
+   | :thread-pool | Thread-pool that captures wait-time in the queue for requests |
+   
+   You should use the returned thread-pool as the worker-pool in your web server."
+  [registry handler thread-count queue-size]
+  (let [{:keys [bounded-thread-pool
+                instrumented-thread-pool]} (make-server-thread-pool thread-count queue-size)
+        app-handler (-> handler
+                        (wrap-queue-latency-middleware registry bounded-thread-pool))]
+    {:handler app-handler
+     :thread-pool instrumented-thread-pool}))

--- a/web/src/org/purefn/kurosawa/web/prometheus.clj
+++ b/web/src/org/purefn/kurosawa/web/prometheus.clj
@@ -38,8 +38,8 @@
         (let [reg (f reg)]
           (when-not (instance? IapetosRegistry reg)
             (throw (ex-info (str "Registration fn passed to PrometheusRegistry must "
-                                 "return an instance of IapetosRegistry"
-                                 {:returned reg}))))
+                                 "return an instance of IapetosRegistry")
+                            {:returned reg})))
           reg))
       (-> (prometheus/collector-registry)
           (ring/initialize


### PR DESCRIPTION
This PR adds support for web server thread-pool instrumentation that logs metrics to Prometheus.

The code in `org.purefn.kurosawa.web.instrument` namespace depends on the optional [Preflex](https://github.com/kumarshantanu/preflex) library to do the heavy lifting of the thread-pool instrumentation mechanism.