### PR TITLE
Jetty as another webserver variant

### DIFF
--- a/aws/project.clj
+++ b/aws/project.clj
@@ -1,4 +1,4 @@
-(defproject org.purefn/kurosawa.aws "2.1.27"
+(defproject org.purefn/kurosawa.aws "2.1.27-SNAPSHOT"
   :plugins [[lein-modules "0.3.11"]]
   :description "AWS Utilities."
   :dependencies [[com.amazonaws/aws-java-sdk-core "1.11.533"]

--- a/aws/project.clj
+++ b/aws/project.clj
@@ -1,8 +1,8 @@
-(defproject org.purefn/kurosawa.aws "2.1.26"
+(defproject org.purefn/kurosawa.aws "2.1.27"
   :plugins [[lein-modules "0.3.11"]]
   :description "AWS Utilities."
   :dependencies [[com.amazonaws/aws-java-sdk-core "1.11.533"]
                  [com.amazonaws/aws-java-sdk-ssm "1.11.533"]
                  [com.amazonaws/aws-java-sdk-s3 "1.11.533"]
                  [org.clojure/data.json "0.2.6"]
-                 [com.taoensso/timbre _]])
+                 [com.taoensso/timbre "4.10.0"]])

--- a/core/project.clj
+++ b/core/project.clj
@@ -1,10 +1,10 @@
-(defproject org.purefn/kurosawa.core "2.1.26"
+(defproject org.purefn/kurosawa.core "2.1.27"
   :plugins [[lein-modules "0.3.11"]]
   :description "The root Kurosawa library."
-  :dependencies [[com.stuartsierra/component _]
-                 [org.clojure/test.check _]
-                 [org.purefn/kurosawa.log _]
-                 [com.gfredericks/test.chuck _]
-                 [com.taoensso/timbre _]]
+  :dependencies [[com.stuartsierra/component "0.3.2"]
+                 [org.clojure/test.check "0.9.0"]
+                 [org.purefn/kurosawa.log "2.1.27"]
+                 [com.gfredericks/test.chuck "0.2.7"]
+                 [com.taoensso/timbre "4.10.0"]]
   :profiles
-  {:dev {:dependencies [[org.purefn/kurosawa.aws _]]}})
+  {:dev {:dependencies [[org.purefn/kurosawa.aws "2.1.27"]]}})

--- a/core/project.clj
+++ b/core/project.clj
@@ -1,10 +1,10 @@
-(defproject org.purefn/kurosawa.core "2.1.27"
+(defproject org.purefn/kurosawa.core "2.1.27-SNAPSHOT"
   :plugins [[lein-modules "0.3.11"]]
   :description "The root Kurosawa library."
   :dependencies [[com.stuartsierra/component "0.3.2"]
                  [org.clojure/test.check "0.9.0"]
-                 [org.purefn/kurosawa.log "2.1.27"]
+                 [org.purefn/kurosawa.log "2.1.27-SNAPSHOT"]
                  [com.gfredericks/test.chuck "0.2.7"]
                  [com.taoensso/timbre "4.10.0"]]
   :profiles
-  {:dev {:dependencies [[org.purefn/kurosawa.aws "2.1.27"]]}})
+  {:dev {:dependencies [[org.purefn/kurosawa.aws "2.1.27-SNAPSHOT"]]}})

--- a/kurosawa/project.clj
+++ b/kurosawa/project.clj
@@ -1,14 +1,14 @@
-(defproject org.purefn/kurosawa "2.1.26"
+(defproject org.purefn/kurosawa "2.1.27"
   :description "A catch-all project that brings in all Kurosawa libs."
   :plugins [[lein-modules "0.3.11"]]
   :packaging "pom"
 
-  :dependencies [[org.purefn/kurosawa.aws _]
-                 [org.purefn/kurosawa.core _]
-                 [org.purefn/kurosawa.log _]
-                 [org.purefn/kurosawa.web _]
-                 [org.purefn/kurosawa.nrepl _]
-                 [com.taoensso/timbre _]
-                 [com.stuartsierra/component _]
-                 [org.clojure/test.check _]
-                 [com.gfredericks/test.chuck _]])
+  :dependencies [[org.purefn/kurosawa.aws "2.1.27"]
+                 [org.purefn/kurosawa.core "2.1.27"]
+                 [org.purefn/kurosawa.log "2.1.27"]
+                 [org.purefn/kurosawa.web "2.1.27"]
+                 [org.purefn/kurosawa.nrepl "2.1.27"]
+                 [com.taoensso/timbre "4.10.0"]
+                 [com.stuartsierra/component "0.3.2"]
+                 [org.clojure/test.check "0.9.0"]
+                 [com.gfredericks/test.chuck "0.2.7"]])

--- a/kurosawa/project.clj
+++ b/kurosawa/project.clj
@@ -1,13 +1,13 @@
-(defproject org.purefn/kurosawa "2.1.27"
+(defproject org.purefn/kurosawa "2.1.27-SNAPSHOT"
   :description "A catch-all project that brings in all Kurosawa libs."
   :plugins [[lein-modules "0.3.11"]]
   :packaging "pom"
 
-  :dependencies [[org.purefn/kurosawa.aws "2.1.27"]
-                 [org.purefn/kurosawa.core "2.1.27"]
-                 [org.purefn/kurosawa.log "2.1.27"]
-                 [org.purefn/kurosawa.web "2.1.27"]
-                 [org.purefn/kurosawa.nrepl "2.1.27"]
+  :dependencies [[org.purefn/kurosawa.aws "2.1.27-SNAPSHOT"]
+                 [org.purefn/kurosawa.core "2.1.27-SNAPSHOT"]
+                 [org.purefn/kurosawa.log "2.1.27-SNAPSHOT"]
+                 [org.purefn/kurosawa.web "2.1.27-SNAPSHOT"]
+                 [org.purefn/kurosawa.nrepl "2.1.27-SNAPSHOT"]
                  [com.taoensso/timbre "4.10.0"]
                  [com.stuartsierra/component "0.3.2"]
                  [org.clojure/test.check "0.9.0"]

--- a/log/project.clj
+++ b/log/project.clj
@@ -1,7 +1,7 @@
-(defproject org.purefn/kurosawa.log "2.1.26"
+(defproject org.purefn/kurosawa.log "2.1.27"
   :plugins [[lein-modules "0.3.11"]]
   :description "A Kurosawa library for logging."
-  :dependencies [[com.taoensso/timbre _]]
-  :profiles {:dev {:dependencies [[org.clojure/tools.namespace _]
-                                  [com.stuartsierra/component _]
-                                  [com.stuartsierra/component.repl _]]}})
+  :dependencies [[com.taoensso/timbre "4.10.0"]]
+  :profiles {:dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
+                                  [com.stuartsierra/component "0.3.2"]
+                                  [com.stuartsierra/component.repl "0.2.0"]]}})

--- a/log/project.clj
+++ b/log/project.clj
@@ -1,4 +1,4 @@
-(defproject org.purefn/kurosawa.log "2.1.27"
+(defproject org.purefn/kurosawa.log "2.1.27-SNAPSHOT"
   :plugins [[lein-modules "0.3.11"]]
   :description "A Kurosawa library for logging."
   :dependencies [[com.taoensso/timbre "4.10.0"]]

--- a/nrepl/project.clj
+++ b/nrepl/project.clj
@@ -1,8 +1,8 @@
-(defproject org.purefn/kurosawa.nrepl "2.1.26"
+(defproject org.purefn/kurosawa.nrepl "2.1.27"
   :plugins [[lein-modules "0.3.11"]]
   :description "The Kurosawa nREPL library."
-  :dependencies [[com.stuartsierra/component _]
-                 [com.taoensso/timbre _]
+  :dependencies [[com.stuartsierra/component "0.3.2"]
+                 [com.taoensso/timbre "4.10.0"]
                  [nrepl "0.6.0"]]
 
   :profiles {:provided

--- a/nrepl/project.clj
+++ b/nrepl/project.clj
@@ -1,4 +1,4 @@
-(defproject org.purefn/kurosawa.nrepl "2.1.27"
+(defproject org.purefn/kurosawa.nrepl "2.1.27-SNAPSHOT"
   :plugins [[lein-modules "0.3.11"]]
   :description "The Kurosawa nREPL library."
   :dependencies [[com.stuartsierra/component "0.3.2"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.purefn/kurosawa "2.1.26"
+(defproject org.purefn/kurosawa "2.1.27"
   :description "Parent for all that is Kurosawa"
   :plugins [[lein-modules "0.3.11"]]
 
@@ -6,8 +6,8 @@
                                        ;; refactor-nrepl to start-up
                                        [org.clojure/clojure "1.10.0"]]}
 
-             :dev {:dependencies [[org.clojure/tools.namespace _]
-                                  [com.stuartsierra/component.repl _]]
+             :dev {:dependencies [[org.clojure/tools.namespace "1.1.0"]
+                                  [com.stuartsierra/component.repl "0.2.0"]]
                    :jvm-opts ["-Xmx2g"]
                    :source-paths ["dev"]
                    :codeina {:sources ["src"]
@@ -32,19 +32,7 @@
                          :url "https://github.com/PureFnOrg/kurosawa"
                          :deploy-repositories
                          [["releases" {:url "https://clojars.org/repo/" :creds :gpg}]
-                          ["snapshots" {:url "https://clojars.org/repo/" :creds :gpg}]]}
-
-             :versions {com.taoensso/timbre             "4.10.0"
-                        com.stuartsierra/component      "0.3.2"
-                        com.stuartsierra/component.repl "0.2.0"
-                        org.clojure/test.check          "0.9.0"
-                        com.gfredericks/test.chuck      "0.2.7"
-                        org.clojure/tools.namespace     "0.2.11"
-                        org.purefn/kurosawa.aws         :version
-                        org.purefn/kurosawa.log         :version
-                        org.purefn/kurosawa.core        :version
-                        org.purefn/kurosawa.web         :version
-                        org.purefn/kurosawa.nrepl       :version}}
+                          ["snapshots" {:url "https://clojars.org/repo/" :creds :gpg}]]}}
 
   :release-tasks [["vcs" "assert-committed"]
                   ["change" "version" "leiningen.release/bump-version" "release"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.purefn/kurosawa "2.1.27"
+(defproject org.purefn/kurosawa "2.1.27-SNAPSHOT"
   :description "Parent for all that is Kurosawa"
   :plugins [[lein-modules "0.3.11"]]
 

--- a/web/project.clj
+++ b/web/project.clj
@@ -3,6 +3,8 @@
   :description "The Kurosawa web library."
   :dependencies [[com.stuartsierra/component _]
 
+                 [ring/ring-core "1.10.0"]
+                 [ring/ring-jetty-adapter "1.10.0"]
                  [http-kit "2.5.3"]
                  [org.immutant/web "2.1.7"
                   :exclusions [ch.qos.logback/logback-classic]]

--- a/web/project.clj
+++ b/web/project.clj
@@ -1,4 +1,4 @@
-(defproject org.purefn/kurosawa.web "2.1.27"
+(defproject org.purefn/kurosawa.web "2.1.27-SNAPSHOT"
   :plugins [[lein-modules "0.3.11"]]
   :description "The Kurosawa web library."
   :dependencies [[com.stuartsierra/component "0.3.2"]
@@ -11,7 +11,7 @@
                  [org.slf4j/log4j-over-slf4j "1.7.25"]
                  [com.fzakaria/slf4j-timbre "0.3.5"]
 
-                 [org.purefn/kurosawa.log "2.1.27"]]
+                 [org.purefn/kurosawa.log "2.1.27-SNAPSHOT"]]
 
   :profiles {:dev {:dependencies [[bidi "2.0.17"]
                                   [clj-commons/iapetos "0.1.9"]

--- a/web/project.clj
+++ b/web/project.clj
@@ -1,7 +1,7 @@
-(defproject org.purefn/kurosawa.web "2.1.26"
+(defproject org.purefn/kurosawa.web "2.1.27"
   :plugins [[lein-modules "0.3.11"]]
   :description "The Kurosawa web library."
-  :dependencies [[com.stuartsierra/component _]
+  :dependencies [[com.stuartsierra/component "0.3.2"]
 
                  [ring/ring-core "1.10.0"]
                  [ring/ring-jetty-adapter "1.10.0"]
@@ -11,7 +11,7 @@
                  [org.slf4j/log4j-over-slf4j "1.7.25"]
                  [com.fzakaria/slf4j-timbre "0.3.5"]
 
-                 [org.purefn/kurosawa.log _]]
+                 [org.purefn/kurosawa.log "2.1.27"]]
 
   :profiles {:dev {:dependencies [[bidi "2.0.17"]
                                   [clj-commons/iapetos "0.1.9"]


### PR DESCRIPTION
- Add `jetty` as another variant of webserver to use via `kurosawa.web`
- Do not use `:versions` from `lein-modules` for version synchronisation across modules since it's no longer working with recent `leiningen`: https://github.com/jcrossley3/lein-modules/issues/45