### PR TITLE
Add datadog JSON appender

### DIFF
--- a/aws/project.clj
+++ b/aws/project.clj
@@ -1,4 +1,4 @@
-(defproject org.purefn/kurosawa.aws "2.1.28"
+(defproject org.purefn/kurosawa.aws "2.1.29-SNAPSHOT"
   :plugins [[lein-modules "0.3.11"]]
   :description "AWS Utilities."
   :dependencies [[com.amazonaws/aws-java-sdk-core "1.11.533"]

--- a/core/project.clj
+++ b/core/project.clj
@@ -1,10 +1,10 @@
-(defproject org.purefn/kurosawa.core "2.1.28"
+(defproject org.purefn/kurosawa.core "2.1.29-SNAPSHOT"
   :plugins [[lein-modules "0.3.11"]]
   :description "The root Kurosawa library."
   :dependencies [[com.stuartsierra/component "0.3.2"]
                  [org.clojure/test.check "0.9.0"]
-                 [org.purefn/kurosawa.log "2.1.28"]
+                 [org.purefn/kurosawa.log "2.1.29-SNAPSHOT"]
                  [com.gfredericks/test.chuck "0.2.7"]
                  [com.taoensso/timbre "4.10.0"]]
   :profiles
-  {:dev {:dependencies [[org.purefn/kurosawa.aws "2.1.28"]]}})
+  {:dev {:dependencies [[org.purefn/kurosawa.aws "2.1.29-SNAPSHOT"]]}})

--- a/kurosawa/project.clj
+++ b/kurosawa/project.clj
@@ -1,13 +1,13 @@
-(defproject org.purefn/kurosawa "2.1.28"
+(defproject org.purefn/kurosawa "2.1.29-SNAPSHOT"
   :description "A catch-all project that brings in all Kurosawa libs."
   :plugins [[lein-modules "0.3.11"]]
   :packaging "pom"
 
-  :dependencies [[org.purefn/kurosawa.aws "2.1.28"]
-                 [org.purefn/kurosawa.core "2.1.28"]
-                 [org.purefn/kurosawa.log "2.1.28"]
-                 [org.purefn/kurosawa.web "2.1.28"]
-                 [org.purefn/kurosawa.nrepl "2.1.28"]
+  :dependencies [[org.purefn/kurosawa.aws "2.1.29-SNAPSHOT"]
+                 [org.purefn/kurosawa.core "2.1.29-SNAPSHOT"]
+                 [org.purefn/kurosawa.log "2.1.29-SNAPSHOT"]
+                 [org.purefn/kurosawa.web "2.1.29-SNAPSHOT"]
+                 [org.purefn/kurosawa.nrepl "2.1.29-SNAPSHOT"]
                  [com.taoensso/timbre "4.10.0"]
                  [com.stuartsierra/component "0.3.2"]
                  [org.clojure/test.check "0.9.0"]

--- a/log/project.clj
+++ b/log/project.clj
@@ -1,7 +1,8 @@
-(defproject org.purefn/kurosawa.log "2.1.28"
+(defproject org.purefn/kurosawa.log "2.1.29-SNAPSHOT"
   :plugins [[lein-modules "0.3.11"]]
   :description "A Kurosawa library for logging."
-  :dependencies [[com.taoensso/timbre "4.10.0"]]
+  :dependencies [[com.taoensso/timbre "4.10.0"]
+                 [org.clojure/data.json "0.2.6"]]
   :profiles {:dev {:dependencies [[org.clojure/tools.namespace "0.2.11"]
                                   [com.stuartsierra/component "0.3.2"]
                                   [com.stuartsierra/component.repl "0.2.0"]]}})

--- a/log/src/org/purefn/kurosawa/log/core.clj
+++ b/log/src/org/purefn/kurosawa/log/core.clj
@@ -6,7 +6,8 @@
             [taoensso.timbre :as log]
             [taoensso.timbre.appenders.core :as append]
             [taoensso.timbre.appenders.3rd-party.rotor :as rotor]
-            [org.purefn.kurosawa.log.api :as api]))
+            [org.purefn.kurosawa.log.api :as api]
+            [org.purefn.kurosawa.log.datadog :as dd]))
 
 (def prod-dir
   "The root directory under which production log files are written."
@@ -87,7 +88,9 @@
                      :locale :jvm-default
                      :timezone (java.util.TimeZone/getTimeZone "America/New_York")}
     :output-fn output-fn
-    :appenders {:stdout (append/println-appender :stream :auto)
+    :appenders {:stdout (if dd/available?
+                          (dd/println-json-appender)
+                          (append/println-appender :stream :auto))
                 :all (rotor/rotor-appender {:path (str dir "/all.log")
                                             :max-size (* 8 1024 1024)
                                             :backlog 10})}}))

--- a/log/src/org/purefn/kurosawa/log/datadog.clj
+++ b/log/src/org/purefn/kurosawa/log/datadog.clj
@@ -1,0 +1,56 @@
+(ns org.purefn.kurosawa.log.datadog
+  (:require
+   [taoensso.timbre :as timbre]
+   [clojure.data.json :as json]))
+
+;; `compile-if` sourced from https://github.com/clojure/core.logic/blob/10ee95eb2bed70af5bc29ea3bd78b380f054a8b4/src/main/clojure/clojure/core/logic/datomic.clj#L1
+(defmacro compile-if
+  "Evaluate `exp` and if it returns logical true and doesn't error, expand to
+  `then`.  Else expand to `else`.
+  (compile-if (Class/forName \"java.util.concurrent.ForkJoinTask\")
+    (do-cool-stuff-with-fork-join)
+    (fall-back-to-executor-services))"
+  [exp then else]
+  (if (try (eval exp)
+           (catch Throwable _ false))
+    `(do ~then)
+    `(do ~else)))
+
+(compile-if (Class/forName "datadog.trace.api.CorrelationIdentifier")
+            (do
+              (import 'datadog.trace.api.CorrelationIdentifier)
+              (defn get-context []
+                {:dd-trace-id (datadog.trace.api.CorrelationIdentifier/getTraceId)
+                 :dd-span-id (datadog.trace.api.CorrelationIdentifier/getSpanId)})
+              (def available? true))
+            (do
+              (defn get-context [] {})
+              (def available? false)))
+
+(defn data->json-string
+  [data]
+  (json/write-str
+   (merge (:context data)
+          (get-context)
+          {:level (:level data)
+           :namespace (:?ns-str data)
+           :file (:?file data)
+           :line (:?line data)
+           :stacktrace (some-> (:?err data) (timbre/stacktrace))
+           :hostname (force (:hostname_ data))
+           :message (force (:msg_ data))
+           "@timestamp" (inst-ms (:instant data))})))
+
+(defn println-json-appender
+  "Returns a DataDog appender, which will send each event in JSON
+  format to stdout. If DataDog tracing library is injected, `dd-trace-id`
+  and `dd-span-id` will be added to the JSON message."
+  [& [_opts]]
+  {:enabled?   true
+   :async?     false
+   :min-level  nil
+   :rate-limit nil
+   :output-fn  data->json-string
+   :fn
+   (fn [{:keys [output_] :as _data}]
+     (println (force output_)))})

--- a/nrepl/project.clj
+++ b/nrepl/project.clj
@@ -1,4 +1,4 @@
-(defproject org.purefn/kurosawa.nrepl "2.1.28"
+(defproject org.purefn/kurosawa.nrepl "2.1.29-SNAPSHOT"
   :plugins [[lein-modules "0.3.11"]]
   :description "The Kurosawa nREPL library."
   :dependencies [[com.stuartsierra/component "0.3.2"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.purefn/kurosawa "2.1.28"
+(defproject org.purefn/kurosawa "2.1.29-SNAPSHOT"
   :description "Parent for all that is Kurosawa"
   :plugins [[lein-modules "0.3.11"]]
 

--- a/web/project.clj
+++ b/web/project.clj
@@ -1,4 +1,4 @@
-(defproject org.purefn/kurosawa.web "2.1.28"
+(defproject org.purefn/kurosawa.web "2.1.29-SNAPSHOT"
   :plugins [[lein-modules "0.3.11"]]
   :description "The Kurosawa web library."
   :dependencies [[com.stuartsierra/component "0.3.2"]
@@ -11,7 +11,7 @@
                  [org.slf4j/log4j-over-slf4j "1.7.25"]
                  [com.fzakaria/slf4j-timbre "0.3.5"]
 
-                 [org.purefn/kurosawa.log "2.1.28"]]
+                 [org.purefn/kurosawa.log "2.1.29-SNAPSHOT"]]
 
   :profiles {:dev {:dependencies [[bidi "2.0.17"]
                                   [clj-commons/iapetos "0.1.9"]


### PR DESCRIPTION
- Add `DataDog` JSON appender
- If DataDog tracing library is injected, it will be used by default over regular `println` variant. Otherwise has no effect.